### PR TITLE
Remove jobs callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,21 @@ that the OTA Job you created is marked as "Successful".
 ## 4. Run the Unit Tests
 
 ### 4.1 Running the OTA Parser Unit tests
-The unit tests are broken out by the 'module' they reside in (aka the /lib folder) and can be executed per module. To run the OTA parser unit tests you'll run the following commands
+
+The unit tests are broken out by the 'module' they reside in (aka the /lib
+folder) and can be executed per module. To run the OTA parser unit tests you'll
+run the following commands
 
 From here you can build the unit tests...
+
 ```
 cd lib/iot-core-jobs-ota-parser
 cmake -B build -S test
 make -C build
 ```
 
-Once built, the test executables can be found under the `lib/iot-core-jobs-ota-parser/build/bin/tests/` directory
+Once built, the test executables can be found under the
+`lib/iot-core-jobs-ota-parser/build/bin/tests/` directory
 
 ## Security
 

--- a/demo/ota_demo.c
+++ b/demo/ota_demo.c
@@ -95,13 +95,13 @@ static bool jobHandlerChain( char * message, size_t messageLength )
     size_t jobIdLength = 0U;
     bool handled = false;
 
+    jobDocLength = coreJobs_getJobDocument( message, messageLength, &jobDoc );
+    jobIdLength = coreJobs_getJobId( message, messageLength, &jobId );
+
     if( globalJobId[ 0 ] == 0 )
     {
         strncpy( globalJobId, jobId, jobIdLength );
     }
-
-    jobDocLength = coreJobs_getJobDocument( message, messageLength, &jobDoc );
-    jobIdLength = coreJobs_getJobId( message, messageLength, &jobId );
 
     if( jobDocLength != 0U && jobIdLength != 0U )
     {

--- a/demo/ota_demo.c
+++ b/demo/ota_demo.c
@@ -34,7 +34,7 @@ static void handleMqttStreamsBlockArrivedCallback(
     MqttFileDownloaderDataBlockInfo_t * dataBlock );
 static void processOtaDocumentCallback( AfrOtaJobDocumentFields_t * params );
 static void finishDownload();
-static bool jobHandlerChain(uint8_t * message, size_t messageLength);
+static bool jobHandlerChain( char * message, size_t messageLength );
 
 void otaDemo_start( void )
 {
@@ -59,19 +59,20 @@ bool otaDemo_handleIncomingMQTTMessage( char * topic,
 {
     bool handled = coreJobs_isStartNextAccepted( topic, topicLength );
 
-    if ( handled )
+    if( handled )
     {
-        handled = jobHandlerChain(message, messageLength);
-        printf( "Handled? %d", handled);
+        handled = jobHandlerChain( ( char * ) message, messageLength );
+        printf( "Handled? %d", handled );
     }
-    else {
+    else
+    {
         handled = mqttDownloader_handleIncomingMessage(
-                             &mqttFileDownloaderContext,
-                             &handleMqttStreamsBlockArrivedCallback,
-                             topic,
-                             topicLength,
-                             message,
-                             messageLength );
+            &mqttFileDownloaderContext,
+            &handleMqttStreamsBlockArrivedCallback,
+            topic,
+            topicLength,
+            message,
+            messageLength );
     }
 
     if( !handled )
@@ -86,7 +87,7 @@ bool otaDemo_handleIncomingMQTTMessage( char * topic,
     return handled;
 }
 
-static bool jobHandlerChain(uint8_t * message, size_t messageLength)
+static bool jobHandlerChain( char * message, size_t messageLength )
 {
     char * jobDoc;
     size_t jobDocLength = 0U;
@@ -94,14 +95,15 @@ static bool jobHandlerChain(uint8_t * message, size_t messageLength)
     size_t jobIdLength = 0U;
     bool handled = false;
 
-    if ( globalJobId[ 0 ] == 0 ) {
+    if( globalJobId[ 0 ] == 0 )
+    {
         strncpy( globalJobId, jobId, jobIdLength );
     }
 
-    jobDocLength = coreJobs_getJobDocument(message, messageLength, &jobDoc);
-    jobIdLength = coreJobs_getJobId(message, messageLength, &jobId);
+    jobDocLength = coreJobs_getJobDocument( message, messageLength, &jobDoc );
+    jobIdLength = coreJobs_getJobId( message, messageLength, &jobId );
 
-    if ( jobDocLength != 0U && jobIdLength != 0U ) 
+    if( jobDocLength != 0U && jobIdLength != 0U )
     {
         handled = otaParser_handleJobDoc( &processOtaDocumentCallback,
                                           jobId,
@@ -194,5 +196,5 @@ static void finishDownload()
                               "2",
                               1U );
     printf( "\033[1;32mOTA Completed successfully!\033[0m\n" );
-    globalJobId[0] = 0U;
+    globalJobId[ 0 ] = 0U;
 }

--- a/lib/iot-core-jobs/source/core_jobs.c
+++ b/lib/iot-core-jobs/source/core_jobs.c
@@ -95,7 +95,7 @@ size_t coreJobs_getJobId(const char * message, size_t messageLength, char ** job
     jsonResult = JSON_Validate( message, messageLength );
     if( jsonResult == JSONSuccess )
     {
-        jsonResult = JSON_Search( message,
+        jsonResult = JSON_Search( ( char * ) message,
                                   messageLength,
                                   "execution.jobId",
                                   sizeof( "execution.jobId" ) - 1,
@@ -112,7 +112,7 @@ size_t coreJobs_getJobDocument(const char * message, size_t messageLength, char 
     jsonResult = JSON_Validate( message, messageLength );
     if( jsonResult == JSONSuccess )
     {
-        jsonResult = JSON_Search( message,
+        jsonResult = JSON_Search( ( char * ) message,
                                   messageLength,
                                   "execution.jobDocument",
                                   sizeof( "execution.jobDocument" ) - 1,

--- a/lib/iot-core-jobs/source/core_jobs.c
+++ b/lib/iot-core-jobs/source/core_jobs.c
@@ -7,7 +7,6 @@
  * the License.
  */
 
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -57,88 +56,71 @@ static size_t getUpdateJobExecutionMsg( JobStatus_t status,
                                         char * buffer,
                                         size_t bufferSize );
 
-bool isMessageJobStartNextAccepted( const char * topic,
-                                    const size_t topicLength )
+/* TODO: Consider creating a 'thingName topic matching' function. This could simply call that function */
+bool coreJobs_isStartNextAccepted( const char * topic,
+                                   const size_t topicLength )
 {
     /* TODO: Inefficient - better implementation shouldn't use snprintf */
-    bool isMatch = false;
     char expectedBuffer[ TOPIC_BUFFER_SIZE + 1 ] = { 0 };
     char thingName[ MAX_THING_NAME_LENGTH + 1 ] = { 0 };
     size_t thingNameLength = 0U;
+    bool isMatch = true;
 
-    mqttWrapper_getThingName( thingName, &thingNameLength );
-    snprintf( expectedBuffer,
+    if ( topic == NULL || topicLength == 0 )
+    {
+        isMatch = false;
+    }
+
+    if ( isMatch )
+    {
+        mqttWrapper_getThingName( thingName, &thingNameLength );
+        snprintf( expectedBuffer,
               TOPIC_BUFFER_SIZE,
               "%s%s%s",
               "$aws/things/",
               thingName,
               "/jobs/start-next/accepted" );
-    isMatch = ( uint32_t ) strnlen( expectedBuffer, TOPIC_BUFFER_SIZE ) ==
+        isMatch = ( uint32_t ) strnlen( expectedBuffer, TOPIC_BUFFER_SIZE ) ==
               topicLength;
-    isMatch = isMatch && strncmp( expectedBuffer, topic, topicLength ) == 0;
+        isMatch = isMatch && strncmp( expectedBuffer, topic, topicLength ) == 0;
+    }
+
     return isMatch;
 }
 
-bool getJobStartNextFields( const uint8_t * message,
-                            const size_t messageLength,
-                            char ** jobId,
-                            size_t * jobIdLength,
-                            char ** jobDoc,
-                            size_t * jobDocLength )
+size_t coreJobs_getJobId(const char * message, size_t messageLength, char ** jobId)
 {
+    size_t jobIdLength = 0U;
     JSONStatus_t jsonResult = JSONNotFound;
-    jsonResult = JSON_Validate( ( char * ) message, messageLength );
+    jsonResult = JSON_Validate( message, messageLength );
     if( jsonResult == JSONSuccess )
     {
-        jsonResult = JSON_Search( ( char * ) message,
+        jsonResult = JSON_Search( message,
                                   messageLength,
                                   "execution.jobId",
                                   sizeof( "execution.jobId" ) - 1,
                                   jobId,
-                                  jobIdLength );
+                                  &jobIdLength );
     }
+    return jobIdLength;
+}
+
+size_t coreJobs_getJobDocument(const char * message, size_t messageLength, char ** jobDoc)
+{
+    size_t jobDocLength = 0U;
+    JSONStatus_t jsonResult = JSONNotFound;
+    jsonResult = JSON_Validate( message, messageLength );
     if( jsonResult == JSONSuccess )
     {
-        jsonResult = JSON_Search( ( char * ) message,
+        jsonResult = JSON_Search( message,
                                   messageLength,
                                   "execution.jobDocument",
                                   sizeof( "execution.jobDocument" ) - 1,
                                   jobDoc,
-                                  jobDocLength );
+                                  &jobDocLength );
     }
-    return jsonResult == JSONSuccess;
-}
 
-/*
- * Can be called on any incoming MQTT message
- * If the incoming MQTT message is intended for an AWS IoT Jobs topic, then
- * this function parses the Job doc and distributes it through the Jobs
- * chain of responsibilities, then returns true. Returns false otherwise.
- */
-bool coreJobs_handleIncomingMQTTMessage(
-    const IncomingJobDocHandler_t jobDocHandler,
-    const char * topic,
-    const size_t topicLength,
-    const uint8_t * message,
-    size_t messageLength )
-{
-    bool willHandle = false;
-    char * jobId = NULL;
-    size_t jobIdLength = 0U;
-    char * jobDoc = NULL;
-    size_t jobDocLength = 0U;
-
-    willHandle = isMessageJobStartNextAccepted( topic, topicLength );
-    willHandle = willHandle && getJobStartNextFields( message,
-                                                      messageLength,
-                                                      &jobId,
-                                                      &jobIdLength,
-                                                      &jobDoc,
-                                                      &jobDocLength );
-
-    willHandle = willHandle &&
-                 ( *jobDocHandler )( jobId, jobIdLength, jobDoc, jobDocLength );
-    return willHandle;
+    return jobDocLength;
 }
 
 bool coreJobs_startNextPendingJob( char * thingname,
@@ -162,7 +144,7 @@ bool coreJobs_startNextPendingJob( char * thingname,
         messageBuffer,
         ( START_JOB_MSG_LENGTH ) );
 
-    if( topicLength > 0 && messageLength > 0 )
+    if( topicLength > 0U && messageLength > 0U )
     {
         published = mqttWrapper_publish( topicBuffer,
                                          topicLength,
@@ -215,19 +197,21 @@ static size_t getStartNextPendingJobExecutionTopic( const char * thingname,
                                                     char * buffer,
                                                     size_t bufferSize )
 {
-    size_t topicLength = 0;
+    size_t topicLength = 0U; 
 
-    assert( bufferSize >= 28U + thingnameLength );
+    if (thingname != NULL && thingnameLength > 0U && ( bufferSize >= 28U + thingnameLength ))
+    {
+        topicLength = sizeof( "$aws/things/" ) - 1;
+        memcpy( buffer, "$aws/things/", sizeof( "$aws/things/" ) - 1 );
+        memcpy( buffer + topicLength, thingname, thingnameLength );
+        topicLength += thingnameLength;
+        memcpy( buffer + topicLength,
+                "/jobs/start-next",
+                sizeof( "/jobs/start-next" ) - 1 );
+        topicLength += sizeof( "/jobs/start-next" ) - 1;
+    }
 
-    topicLength = sizeof( "$aws/things/" ) - 1;
-    memcpy( buffer, "$aws/things/", sizeof( "$aws/things/" ) - 1 );
-    memcpy( buffer + topicLength, thingname, thingnameLength );
-    topicLength += thingnameLength;
-    memcpy( buffer + topicLength,
-            "/jobs/start-next",
-            sizeof( "/jobs/start-next" ) - 1 );
-
-    return topicLength + sizeof( "/jobs/start-next" ) - 1;
+    return topicLength;
 }
 
 static size_t getStartNextPendingJobExecutionMsg( const char * clientToken,
@@ -235,19 +219,21 @@ static size_t getStartNextPendingJobExecutionMsg( const char * clientToken,
                                                   char * buffer,
                                                   size_t bufferSize )
 {
-    size_t messageLength = 0;
+    size_t messageLength = 0U;
 
-    assert( bufferSize >= 18U + clientTokenLength );
+    if ( clientToken != NULL  && clientTokenLength > 0U && ( bufferSize >= 18U + clientTokenLength ) )
+    {
+        messageLength = sizeof( "{\"clientToken\":\"" ) - 1;
+        memcpy( buffer,
+                "{\"clientToken\":\"",
+                sizeof( "{\"clientToken\":\"" ) - 1 );
+        memcpy( buffer + messageLength, clientToken, clientTokenLength );
+        messageLength += clientTokenLength;
+        memcpy( buffer + messageLength, "\"}", sizeof( "\"}" ) - 1 );
+        messageLength += sizeof( "\"}" ) - 1;
+    }
 
-    messageLength = sizeof( "{\"clientToken\":\"" ) - 1;
-    memcpy( buffer,
-            "{\"clientToken\":\"",
-            sizeof( "{\"clientToken\":\"" ) - 1 );
-    memcpy( buffer + messageLength, clientToken, clientTokenLength );
-    messageLength += clientTokenLength;
-    memcpy( buffer + messageLength, "\"}", sizeof( "\"}" ) - 1 );
-
-    return messageLength + sizeof( "\"}" ) - 1;
+    return messageLength;
 }
 
 static size_t getUpdateJobExecutionTopic( char * thingname,
@@ -259,19 +245,21 @@ static size_t getUpdateJobExecutionTopic( char * thingname,
 {
     size_t topicLength = 0;
 
-    assert( bufferSize >= 25U + thingnameLength + jobIdLength );
+    if ( thingname != NULL && jobId != NULL && thingnameLength > 0U && jobIdLength > 0U && (( bufferSize >= 25U + thingnameLength + jobIdLength )))
+    {
+        topicLength = sizeof( "$aws/things/" ) - 1;
+        memcpy( buffer, "$aws/things/", sizeof( "$aws/things/" ) - 1 );
+        memcpy( buffer + topicLength, thingname, thingnameLength );
+        topicLength += thingnameLength;
+        memcpy( buffer + topicLength, "/jobs/", sizeof( "/jobs/" ) - 1 );
+        topicLength += sizeof( "/jobs/" ) - 1;
+        memcpy( buffer + topicLength, jobId, jobIdLength );
+        topicLength += jobIdLength;
+        memcpy( buffer + topicLength, "/update", sizeof( "/update" ) - 1 );
+        topicLength += sizeof( "/update" ) - 1;
+    }
 
-    topicLength = sizeof( "$aws/things/" ) - 1;
-    memcpy( buffer, "$aws/things/", sizeof( "$aws/things/" ) - 1 );
-    memcpy( buffer + topicLength, thingname, thingnameLength );
-    topicLength += thingnameLength;
-    memcpy( buffer + topicLength, "/jobs/", sizeof( "/jobs/" ) - 1 );
-    topicLength += sizeof( "/jobs/" ) - 1;
-    memcpy( buffer + topicLength, jobId, jobIdLength );
-    topicLength += jobIdLength;
-    memcpy( buffer + topicLength, "/update", sizeof( "/update" ) - 1 );
-
-    return topicLength + sizeof( "/update" ) - 1;
+    return topicLength;
 }
 
 static size_t getUpdateJobExecutionMsg( JobStatus_t status,
@@ -282,23 +270,25 @@ static size_t getUpdateJobExecutionMsg( JobStatus_t status,
 {
     size_t messageLength = 0;
 
-    assert( bufferSize >=
-            34U + expectedVersionLength + jobStatusStringLengths[ status ] );
+    if ( expectedVersion != NULL && expectedVersionLength > 0U && bufferSize >=
+            34U + expectedVersionLength + jobStatusStringLengths[ status ] )
+    {
+        messageLength = sizeof( "{\"status\":\"" ) - 1;
+        memcpy( buffer, "{\"status\":\"", sizeof( "{\"status\":\"" ) - 1 );
+        memcpy( buffer + messageLength,
+                jobStatusString[ status ],
+                jobStatusStringLengths[ status ] );
 
-    messageLength = sizeof( "{\"status\":\"" ) - 1;
-    memcpy( buffer, "{\"status\":\"", sizeof( "{\"status\":\"" ) - 1 );
-    memcpy( buffer + messageLength,
-            jobStatusString[ status ],
-            jobStatusStringLengths[ status ] );
+        messageLength += jobStatusStringLengths[ status ];
+        memcpy( buffer + messageLength,
+                "\",\"expectedVersion\":\"",
+                sizeof( "\",\"expectedVersion\":\"" ) - 1 );
+        messageLength += sizeof( "\",\"expectedVersion\":\"" ) - 1;
+        memcpy( buffer + messageLength, expectedVersion, expectedVersionLength );
+        messageLength += expectedVersionLength;
+        memcpy( buffer + messageLength, "\"}", sizeof( "\"}" ) - 1 );
+        messageLength += sizeof( "\"}" ) - 1;
+    }
 
-    messageLength += jobStatusStringLengths[ status ];
-    memcpy( buffer + messageLength,
-            "\",\"expectedVersion\":\"",
-            sizeof( "\",\"expectedVersion\":\"" ) - 1 );
-    messageLength += sizeof( "\",\"expectedVersion\":\"" ) - 1;
-    memcpy( buffer + messageLength, expectedVersion, expectedVersionLength );
-    messageLength += expectedVersionLength;
-    memcpy( buffer + messageLength, "\"}", sizeof( "\"}" ) - 1 );
-
-    return messageLength + sizeof( "\"}" ) - 1;
+    return messageLength;
 }

--- a/lib/iot-core-jobs/source/include/core_jobs.h
+++ b/lib/iot-core-jobs/source/include/core_jobs.h
@@ -70,20 +70,27 @@ bool coreJobs_updateJobStatus( char * thingname,
                                char * expectedVersion,
                                size_t expectedVersionLength );
 
-/*
- * ------------------------ MQTT API Functions  --------------------------
- * Called by the platform wrapper, implemented by coreJobs
- *
- * Can be called on any incoming MQTT message
- * If the incoming MQTT message is intended for an AWS IoT Jobs topic, then this
- * function parses the Job doc and distributes it through the Jobs chain of
- * responsibilities, then returns true. Returns false otherwise.
+/**
+ * @brief Retrieves the job ID from a given message (if applicable)
+ * 
+ * @param message [In] A JSON formatted message which
+ * @param messageLength [In] The length of the message
+ * @param jobId [Out] The job ID
+ * @return size_t The job ID length
  */
-bool coreJobs_handleIncomingMQTTMessage(
-    const IncomingJobDocHandler_t jobDocHandler,
-    const char * topic,
-    const size_t topicLength,
-    const uint8_t * message,
-    size_t messageLength );
+size_t coreJobs_getJobId(const char * message, size_t messageLength, char ** jobId);
+
+/**
+ * @brief Retrieves the job document from a given message (if applicable)
+ * 
+ * @param message [In] A JSON formatted message which
+ * @param messageLength [In] The length of the message
+ * @param jobDoc [Out] The job document
+ * @return size_t The length of the job document
+ */
+size_t coreJobs_getJobDocument(const char * message, size_t messageLength, char ** jobDoc);
+
+bool coreJobs_isStartNextAccepted( const char * topic,
+                                   const size_t topicLength );
 
 #endif


### PR DESCRIPTION
### Description of Changes
Remove jobs method which takes
callback in favor of a more procedural
style of calls.

### Manual testing steps
Ran demo. Output below...

```
D Transport_OpenSSL: Successfully imported root CA.
D Transport_OpenSSL: Successfully imported client certificate.
D Transport_OpenSSL: Successfully imported client certificate private key.
D Transport_OpenSSL: Setting server name a77n9d666fj2p-ats.iot.us-east-1.amazonaws.com for SNI.
D Transport_OpenSSL: Established a TLS connection.
Successfully connected to IoT Core
Data topic is $aws/things/DevDesktopThing/streams/AFR_OTA-<redacted>/data/json
Get stream topic is $aws/things/DevDesktopThing/streams/AFR_OTA-<redacted>/get/json
Handled? 1SUBACK received with packet id: 2
MQTT streams handling incoming message 
Incoming Publish Topic Length: 90 Name: $aws/things/DevDesktopThing/streams/AFR_OTA-<redacted>/data/json matches subscribed topic.
Incoming Publish Message length: 43 Message: {"f":0,"i":0,"l":12,"p":"aGVsbG8gd29ybGQK"}
Downloaded Data hello world
```

### Unit tests
Will be added in https://github.com/FreeRTOS/Labs-Project-ota-example-for-aws-iot-core/pull/29

### Backward compatibility of data and changes
#### Is the change rollback friendly? Think about state in DynamoDB or other resources created by the new code and whether the old code can handle it. 

Manual testing suggests there is no backwards feature regression. I expect this to be backwards compatible.
